### PR TITLE
Updated User Auto Complete Search API

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -7531,7 +7531,7 @@ kong_apis:
           
   - name: userAutoComplete
     uris: "{{ user_service_prefix }}/v1/autocomplete"
-    upstream_url: "{{ learning_service_url }}/v1/user/autocomplete"
+    upstream_url: "{{ sb_cb_ext_service_url }}/user/v1/autocomplete"
     strip_uri: true
     plugins:
     - name: jwt


### PR DESCRIPTION
Using cb-ext service for auto complete user search instead of learner service. Cb-Ext API will return only the active users.