### PR TITLE
Using cb-ext APIs instead of learner

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -7547,7 +7547,7 @@ kong_apis:
           
   - name: userAutoComplete
     uris: "{{ user_service_prefix }}/v1/autocomplete"
-    upstream_url: "{{ learning_service_url }}/v1/user/autocomplete"
+    upstream_url: "{{ sb_cb_ext_service_url }}/user/v1/autocomplete"
     strip_uri: true
     plugins:
     - name: jwt
@@ -7768,7 +7768,7 @@ kong_apis:
       
   - name: privateUserMigrate
     uris: "{{ user_service_prefix }}/private/v1/migrate"
-    upstream_url: "{{ learning_service_url }}/private/user/v1/migrate"
+    upstream_url: "{{ sb_cb_ext_service_url }}/user/v1/migrate"
     strip_uri: true
     plugins:
     - name: jwt
@@ -8896,4 +8896,21 @@ kong_apis:
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
 
+  - name: searchUserPrivate
+    uris: "{{ learner_private_route_prefix }}/user/v1/search"
+    upstream_url: "{{ learning_service_url }}/private/user/v1/search"
+    strip_uri: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist:
+        - 'userAccess'
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ small_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
 


### PR DESCRIPTION
Mapping to cb-ext APIs for user migrate, user auto complete APIs and added Search API for parichay login